### PR TITLE
Modify permissions on CourseCreator table to give add/delete access to admin user

### DIFF
--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -41,7 +41,7 @@ class CourseCreatorAdmin(admin.ModelAdmin):
     # Controls the order on the edit form (without this, read-only fields appear at the end).
     fieldsets = (
         (None, {
-            'fields': ['username', 'state', 'state_changed', 'note']
+            'fields': ['user', 'username', 'state', 'state_changed', 'note']
         }),
     )
     # Fields that filtering support
@@ -62,10 +62,10 @@ class CourseCreatorAdmin(admin.ModelAdmin):
     username.admin_order_field = 'user__username'
 
     def has_add_permission(self, request):
-        return False
+        return request.user.is_superuser
 
     def has_delete_permission(self, request, obj=None):
-        return False
+        return request.user.is_superuser
 
     def has_change_permission(self, request, obj=None):
         return request.user.is_staff


### PR DESCRIPTION
## Description:
Allow admin users to add/delete course-creators from django admin panel.

### Changes:
- Modifications in admin.py on CourseCreator model to give CRUD access to Admin users.