### PR TITLE
Use issuer-slug and mode combination to search badgr class.

### DIFF
--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -92,7 +92,7 @@ class BadgeClass(models.Model):
         if not course_id:
             course_id = CourseKeyField.Empty
         try:
-            return cls.objects.get(slug=slug, issuing_component=issuing_component, course_id=course_id)
+            return cls.objects.get(mode=mode, issuing_component=issuing_component, course_id=course_id)
         except cls.DoesNotExist:
             if not create:
                 return None


### PR DESCRIPTION
## Description

System try to search existing badgr class otherwise create new one with some generic information and empty "badge_server_slug". The "badge_server_slug" can not be empty as it is being used in further awards API calls. We have to stop system from creating new default badgr class.

Before changes, system was using class-slug (course_id + hashed string) to search badgr class, and as we are generating badgr class manually so we have to use our custom slug format as a result of this system gives class not found exception and try to create invalid generic badgr class.

In this PR, we have tried to overcome this issue by using mode and issuer_slog combination to find exact badgr class instead of random system slug.
