### PR TITLE
Certification info text moved in config

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -142,6 +142,9 @@ def _update_certificate_context(context, course, user_certificate, platform_name
         platform_name=platform_name,
     )
 
+    # Translators: This text fragment appears after the signatures (displayed in a small font) on the certificate
+    context['certificate_info'] = _("Certificate Info")
+
 
 def _update_context_with_basic_info(context, course_id, platform_name, configuration):
     """

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -52,7 +52,7 @@ course_mode_class = course_mode if course_mode else ''
                         </div>
                         % endif
                         <div class="accomplishment-info">
-                            <p>${_("The holder of this certificate has demonstrated the knowledge and skills required to become a Certified Trainer and they are able to implement the Reading Wikipedia in the Classroom program in their country. For a list of all Certified Trainers of this program visit:")} <a href="&#104;&#116;&#116;&#112;&#115;://&#119;&#046;&#119;&#105;&#107;&#105;/&#052;&#088;&#052;&#056;" target="_blank">${_("https://w.wiki/4X48")}</a></p>
+                            <p>${certificate_info}</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51116673/146364908-ff4e0581-a25a-42a3-b97c-e67cc48893eb.png)

Add the following config for certification info text.
```
{
    ...
    "certificate_info": "The holder of this certificate has demonstrated the knowledge and skills required to become a Certified Trainer and they are able to implement the Reading Wikipedia in the Classroom program in their country. For a list of all Certified Trainers of this program visit: https://w.wiki/4X48"
    ...
}
```