### PR TITLE
Fix evidence_url/certificate_url issue

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -33,6 +33,7 @@ from openedx.core.djangoapps.signals.signals import (
     COURSE_GRADE_NOW_PASSED,
     LEARNER_NOW_VERIFIED
 )
+from openedx.features.wikimedia_features.wikimedia_general.utils import is_course_graded
 
 log = logging.getLogger(__name__)
 
@@ -107,7 +108,8 @@ def _listen_for_failing_grade(sender, user, course_id, grade, **kwargs):  # pyli
 
     cert = GeneratedCertificate.certificate_for_student(user, course_id)
     if cert is not None:
-        if CertificateStatuses.is_passing_status(cert.status):
+        # [Wikimedia-Custom] Mark certificate state notpassing only if course has graded assignments.
+        if CertificateStatuses.is_passing_status(cert.status) and is_course_graded(course_id, user):
             cert.mark_notpassing(grade.percent)
             log.info('Certificate marked not passing for {user} : {course} via failing grade: {grade}'.format(
                 user=user.id,

--- a/openedx/features/wikimedia_features/wikimedia_general/utils.py
+++ b/openedx/features/wikimedia_features/wikimedia_general/utils.py
@@ -1,0 +1,33 @@
+
+import six
+
+from django.test import RequestFactory
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.features.course_experience.utils import get_course_outline_block_tree
+
+
+def is_course_graded(course_id, user, request=None):
+    """
+    Check that course is graded.
+
+    Arguments:
+        course_id: (CourseKey/String) if CourseKey turn it into string
+        request: (WSGI Request/None) if None create your own dummy request object
+
+    Returns:
+        is_graded (bool)
+    """
+    if request is None:
+        request = RequestFactory().get(u'/')
+        request.user = user
+
+    if isinstance(course_id, CourseKey):
+        course_id = six.text_type(course_id)
+
+    course_outline = get_course_outline_block_tree(request, course_id, user)
+
+    if course_outline:
+        return course_outline.get('num_graded_problems') > 0
+    else:
+        return False


### PR DESCRIPTION
## Bug Reported: 
    Evidence link on the badge is taking us to a "Page not found" on WikiLearn.

## Problem Explanation:
-  Badgr uses certificate_url as evidence_url.
-  Issue is only for ungraded courses -> courses without graded subsections.
-  As course is un-graded, edX marks certificate state not-passing at the time of certificates and badge generation and set invalid certificate_url as evidence_url for that badge.
-  Invalid certificate_ur/evidence_url raises not-found exception on LMS.
    
## Solution:
 - Check if course is graded-course before changing certificate state as not-passing on grade calculations.