### PR TITLE
Multilingual Feature -> fix issue of translation mapping and video transcript

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/models.py
+++ b/openedx/features/wikimedia_features/meta_translations/models.py
@@ -77,6 +77,15 @@ class WikiTranslation(models.Model):
                 source_block_data=base_course_block_data,
             )
             log.info("Mapping has been created for data_type {}, value {}".format(key, value))
+        except CourseBlockData.MultipleObjectsReturned:
+            index = target_block.block_id.rindex("@")
+            reference_key =  target_block.block_id[index+1:]
+            base_course_block_data = base_course_blocks_data.get(course_block__block_id__endswith=reference_key, data_type=key, data=value)
+            WikiTranslation.objects.create(
+                target_block=target_block,
+                source_block_data=base_course_block_data,
+            )
+            log.info("Mapping has been created for data_type {}, value {}".format(key, value))
         except CourseBlockData.DoesNotExist:
             log.error("Error -> Unable to find source block mapping for key {}, value {} of course: {}".format(
                 key, value, six.text_type(target_block.course_id))

--- a/openedx/features/wikimedia_features/meta_translations/utils.py
+++ b/openedx/features/wikimedia_features/meta_translations/utils.py
@@ -45,7 +45,7 @@ def get_video_components_data(block):
     json_content = json.loads(data['content'].decode("utf-8"))
     return {
         "display_name": block.display_name,
-        "transcript": json_content['text']
+        "transcript": json.dumps(json_content['text'])
     }
 
 def get_module_data(block):


### PR DESCRIPTION
PR contains following fixes:
- handle mapping case -  when course blocks contains same data for translation with in same course i.e two sections have same display name.
- Store video transcripts text as json in DB so that it can be retrieved easily.