### PR TITLE
Tehreem/add ping mention in discussion forum with email notifications

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -116,7 +116,8 @@
                 threads: '/courses/' + $$course_id + '/discussion/forum',
                 enable_notifications: '/notification_prefs/enable/',
                 disable_notifications: '/notification_prefs/disable/',
-                notifications_status: '/notification_prefs/status/'
+                notifications_status: '/notification_prefs/status/',
+                user_search: '/messenger/api/v0/user/?search=' + param
             }[name];
         };
 
@@ -323,6 +324,49 @@
             });
         };
 
+        DiscussionUtil.searchMentionedUsers = _.debounce(function(event) {
+            // enable user to ping/mention other users using @usernames on discussion form
+            $( ".username-query" ).remove();
+            var content = event.target.value;
+            var index = content.lastIndexOf("@");
+            var name = "";
+            if (index != -1) {
+                name = content.substr(index + 1);
+                $.ajax({
+                    type: 'GET',
+                    url: this.urlFor('user_search', name),
+                    data: {},
+                }).done(function(response) {
+                    console.log(name)
+                    console.log(response.results)
+                    var div = document.createElement("div");
+                    div.setAttribute("class", "username-query");
+                    $.each(response.results, function(index) {
+                        var btn = document.createElement("button");
+                        btn.setAttribute("class", "username-btn btn btn-outline-primary");
+                        btn.setAttribute("value",  response.results[index].username + "/" + event.target.id);
+                        btn.textContent = response.results[index].username
+
+                        btn.addEventListener("click", function(event) {
+                            event.preventDefault();
+                            var [name, input_id]= event.target.value.split("/")
+                            var target = document.getElementById(input_id)
+                            var index= target.value.lastIndexOf("@");
+                            target.value = target.value.substring(0, index+1) + name;
+                            $(".wmd-panel.wmd-preview p").html(target.value);
+                            $(".username-query").hide();
+                        })
+                        div.appendChild(btn)
+                    });
+                    event.target.after(div)
+                }).fail(function(jqXHR, textStatus) {
+                   console.log("Error has been occurred in user search query.")
+                   console.log(textStatus)
+                });
+            }
+        }, 500);
+
+
         DiscussionUtil.makeWmdEditor = function($content, $local, cls_identifier) {
             var appended_id, editor, elem, id, imageUploadUrl, placeholder, _processor;
             elem = $local('.' + cls_identifier);
@@ -338,9 +382,12 @@
             };
             editor = Markdown.makeWmdEditor(elem, appended_id, imageUploadUrl, _processor(this));
             this.wmdEditors['' + cls_identifier + '-' + id] = editor;
+            var input = elem.find('#wmd-input' + appended_id);
+
             if (placeholder) {
-                elem.find('#wmd-input' + appended_id).attr('placeholder', placeholder);
+                input.attr('placeholder', placeholder);
             }
+            input[0].addEventListener('input', function(event) {DiscussionUtil.searchMentionedUsers(event)})
             return editor;
         };
 

--- a/openedx/features/wikimedia_features/email/message_types.py
+++ b/openedx/features/wikimedia_features/email/message_types.py
@@ -3,6 +3,12 @@ from openedx.core.djangoapps.ace_common.message import BaseMessageType
 
 class PendingMessagesNotification(BaseMessageType):
     """
-    A message for notifying users about pending messages.
+    A message for notifying users about pending messages on offline messenger app.
     """
     APP_LABEL = 'messenger'
+
+class ThreadMentionNotification(BaseMessageType):
+    """
+    A message for notifying users that they have been mentioned in a post/response/comment on discussion forum.
+    """
+    APP_LABEL = 'wikimedia_general'

--- a/openedx/features/wikimedia_features/messenger/tasks.py
+++ b/openedx/features/wikimedia_features/messenger/tasks.py
@@ -11,12 +11,11 @@ log = getLogger(__name__)
 
 @task(base=LoggedTask)
 def send_unread_messages_email_task(data):
-    try:
-        request_user = User.objects.get(username=settings.EMAIL_ADMIN)
-        for username, context in data.items():
+    for username, context in data.items():
+        try:
             user = User.objects.get(username=username)
-            send_unread_messages_email(user, context, request_user)
-    except User.DoesNotExist:
-        log.error(
-            "Unable to send email as Email Admin User with username: {} does not exist.".format(settings.EMAIL_ADMIN)
-        )
+            send_unread_messages_email(user, context)
+        except User.DoesNotExist:
+            log.error(
+                "Unable to send email User with username: {} does not exist.".format(settings.EMAIL_ADMIN)
+            )

--- a/openedx/features/wikimedia_features/wikimedia_general/signals.py
+++ b/openedx/features/wikimedia_features/wikimedia_general/signals.py
@@ -6,13 +6,26 @@ from logging import getLogger
 from django.conf import settings
 from django.dispatch import receiver
 from django.db.models.signals import post_save
+from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.course_modes.models import CourseMode
 from xmodule.modulestore.django import SignalHandler
+from openedx.core.djangoapps.django_comment_common.signals import (
+    comment_created, comment_edited, thread_created, thread_edited,
+)
+from openedx.core.djangoapps.theming.helpers import get_current_site
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.features.wikimedia_features.wikimedia_general.utils import (
+    is_discussion_notification_configured_for_site
+)
+from openedx.features.wikimedia_features.wikimedia_general.tasks import send_thread_mention_email_task
+from openedx.features.wikimedia_features.email.utils import (
+    update_context_with_thread,
+    update_context_with_comment,
+    build_discussion_notification_context
+)
 
 logger = getLogger(__name__)
-
 
 @receiver(post_save, sender=CourseOverview)
 def create_default_course_mode(sender, instance, created, **kwargs):
@@ -38,3 +51,36 @@ def create_default_course_mode(sender, instance, created, **kwargs):
             course_mode.save()
         else:
             logger.info('Default mode set is Audit - no need to change course mode.')
+
+@receiver(comment_created)
+@receiver(comment_edited)
+@receiver(thread_created)
+@receiver(thread_edited)
+def send_thread_mention_email_notification(sender, user, post, **kwargs):
+    """
+    This function will retrieve list of tagged usernames from discussion post/response
+    and then send email notifications to all tagged usernames.
+    Arguments:
+        sender: Model from which we received signal (we are not using it in this case).
+        user: Thread/Comment owner
+        post: Thread/Comment that is being created/edited
+        kwargs: Remaining key arguments of signal.
+    """
+    is_thread = post.type == 'thread'
+    current_site = get_current_site()
+    if not is_discussion_notification_configured_for_site(current_site, post.id):
+        return
+    course_key = CourseKey.from_string(post.course_id)
+    context = {
+        'course_id': course_key,
+        'site': current_site,
+        'is_thread': is_thread
+    }
+
+    if is_thread:
+        update_context_with_thread(context, post)
+    else:
+        update_context_with_thread(context, post.thread)
+        update_context_with_comment(context, post)
+    message_context = build_discussion_notification_context(context)
+    send_thread_mention_email_task.delay(post.body, message_context, is_thread)

--- a/openedx/features/wikimedia_features/wikimedia_general/tasks.py
+++ b/openedx/features/wikimedia_features/wikimedia_general/tasks.py
@@ -1,0 +1,33 @@
+import markdown
+from logging import getLogger
+from celery import task
+from celery_utils.logged_task import LoggedTask
+from django.conf import settings
+from django.contrib.auth.models import User
+
+from openedx.features.wikimedia_features.email.utils import send_thread_mention_email
+from openedx.features.wikimedia_features.wikimedia_general.utils import (
+    get_mentioned_users_list
+)
+
+log = getLogger(__name__)
+
+
+@task(base=LoggedTask)
+def send_thread_mention_email_task(post_body, context, is_thread):
+    log.info("Initiated task to send thread mention notifications.")
+
+    # convert markdown post_body to html
+    processed_post_body = markdown.markdown(post_body)
+
+    # Replace few chars to handle cases i.e "<h1>@username</h1>" or <h1>@username/n</h1> so it will be easy
+    # to retrieve mentioned usernames as usernames will be in between '@' and ' ' characters in processed_post_body.
+    processed_post_body = processed_post_body.replace("\n", " ").replace("</", " ")
+
+    users_list = get_mentioned_users_list(processed_post_body)
+
+    if users_list:
+        receipients = [user.email for user in users_list]
+        send_thread_mention_email(receipients, context, is_thread)
+    else:
+        log.info("No user is tagged on thread/comment of discussion forum.")

--- a/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/body.html
+++ b/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/body.html
@@ -1,0 +1,42 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <p>
+                {% if is_thread %}
+                    {% blocktrans trimmed %}
+                        {{ thread_username }} mentioned you on post: <b>{{ thread_title }}</b>:
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed %}
+                            {{ comment_username }} mentioned you in the comment on post: <b>{{ thread_title }}</b>:
+                    {% endblocktrans %}
+                {% endif %}
+            </p>
+            <div style="border-left: 1px solid rgba(0,0,0,0.25);
+                    padding: 1px 1px 1px 15px;
+                    margin: 20px 20px 30px 30px;
+                    color: rgba(0,0,0,.75);">
+
+                {% if is_thread %}
+                    {{ thread_body|safe}}
+                {% else %}
+                    {{ comment_body|safe }}
+                {% endif %}
+
+            </div>
+
+            {% trans "View discussion" as course_cta_text %}
+            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=post_link%}
+
+            {% block google_analytics_pixel %}
+                <img src="{{ ga_tracking_pixel_url }}" alt="" role="presentation" aria-hidden="true" style="display: block;"/>
+            {% endblock %}
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/body.txt
+++ b/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/body.txt
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% block content %}
+{% if is_thread %}
+{% blocktrans trimmed %}{{ thread_username }} mentioned you on post: {{ thread_title }}:{% endblocktrans %}
+{% else %}
+{% blocktrans trimmed %}{{ comment_username }} mentioned you in the comment on post: {{ thread_title }}:{% endblocktrans %}
+{% endif %}
+{% if is_thread %}
+    {{ thread_body }}
+{% else %}
+    {{ comment_body }}
+{% endif %}
+{% trans "View discussion" %} -> {{ post_link }}
+{% endblock %}

--- a/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/from_name.txt
+++ b/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/from_name.txt
@@ -1,0 +1,1 @@
+{{ platform_name }}

--- a/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/head.html
+++ b/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/head.html
@@ -1,0 +1,1 @@
+{% extends 'ace_common/edx_ace/common/base_head.html' %}

--- a/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/subject.txt
+++ b/openedx/features/wikimedia_features/wikimedia_general/templates/wikimedia_general/edx_ace/threadmentionnotification/email/subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% blocktrans %}{{ subject }}{% endblocktrans %}

--- a/openedx/features/wikimedia_features/wikimedia_general/utils.py
+++ b/openedx/features/wikimedia_features/wikimedia_general/utils.py
@@ -1,10 +1,16 @@
-
+import logging
 import six
 
 from django.test import RequestFactory
+from django.contrib.auth import get_user_model
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.features.course_experience.utils import get_course_outline_block_tree
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+
+log = logging.getLogger(__name__)
+User = get_user_model()
+ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY = 'enable_forum_notifications'
 
 
 def is_course_graded(course_id, user, request=None):
@@ -31,3 +37,40 @@ def is_course_graded(course_id, user, request=None):
         return course_outline.get('num_graded_problems') > 0
     else:
         return False
+
+def is_discussion_notification_configured_for_site(site, post_id):
+    if site is None:
+        log.info('Discussion: No current site, not sending notification about new thread: %s.', post_id)
+        return False
+    try:
+        if not site.configuration.get_value(ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY, False):
+            log_message = 'Discussion: notifications not enabled for site: %s. Not sending message about new thread: %s'
+            log.info(log_message, site, post_id)
+            return False
+    except SiteConfiguration.DoesNotExist:
+        log_message = 'Discussion: No SiteConfiguration for site %s. Not sending message about new thread: %s.'
+        log.info(log_message, site, post_id)
+        return False
+    return True
+
+
+def get_mentioned_users_list(input_string, users_list=None):
+    if not users_list:
+        users_list = []
+
+    start_index = input_string.find("@")
+    if start_index == -1:
+        return users_list
+    else:
+        end_index = input_string[start_index:].find(" ")
+        name = input_string[start_index:][:end_index]
+
+        try:
+            user = User.objects.get(username=name[1:]) #remove @ from name
+            users_list.append(user)
+        except User.DoesNotExist:
+            log.error("Unable to find mentioned thread user with name: {}".format(name))
+
+        # remove tagged name from string and search for next tagged name
+        remianing_string = input_string.replace(name, "")
+        return get_mentioned_users_list(remianing_string, users_list)


### PR DESCRIPTION
## Description
Add ping/mention feature in discussion forums so that users can mention other users in their post/response/comments using @username. Mentioned users will get an email notification for the related post.

### Related theme PR(s): 
https://github.com/wikimedia/wikilearn-edx-theme/pull/31
https://github.com/wikimedia/wikilearn-edx-theme/pull/30

### Ticket link: 
https://edlyio.atlassian.net/browse/WM-88

SS from local testing:
![image](https://user-images.githubusercontent.com/42185078/167838148-d2efb69b-62ef-4fda-a42c-bdf8cbb4462c.png)

![image](https://user-images.githubusercontent.com/42185078/167838297-68093fb0-9e7a-4291-938b-fa63166a4861.png)
