### PR TITLE
Add switch for admin to filter out own created courses on meta translation page

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/static/translations/js/TranslationContent.js
+++ b/openedx/features/wikimedia_features/meta_translations/static/translations/js/TranslationContent.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import { ToastContainer } from 'react-toastify';
+import Switch from "react-switch";
 
 import Select from "./components/Select";
 import useFetch from "./hooks/useFetch";
@@ -15,10 +16,11 @@ function TranslationContent({ context }) {
   const [courseOutline, setCourseOutline] = useState({});
   const [isLoading, setLoading] = useState(true);
   const { fetchCourses, fetchCourseOutline } = useFetch(context);
+  const [filterAdminCourses, setFilterAdminCourses] = useState(false);
 
   useEffect(() => {
-    fetchCourses(setBaseCourses, setLoading);
-  }, []);
+    fetchCourses(setBaseCourses, setLoading, filterAdminCourses);
+  }, [filterAdminCourses]);
 
   const handleBaseCourseChange = (value) => {
     setBaseCourse(value);
@@ -37,6 +39,23 @@ function TranslationContent({ context }) {
     }
   }
 
+  const handleAdminFilterCourses = (event) => {
+    setCourseOutline({});
+    setRerunCourses([]);
+    setFilterAdminCourses(!filterAdminCourses);
+  }
+
+  const renderAdminButton = () => {
+    if (context.IS_ADMIN == "True") {
+      return (
+      <label>
+        <span>Filter My Courses</span>
+        <Switch onChange={handleAdminFilterCourses} checked={filterAdminCourses} />
+      </label>
+      )
+    }
+  }
+
   return (
     <div className="translations">
       <div className="message">
@@ -47,6 +66,7 @@ function TranslationContent({ context }) {
           </p>
         }
       </div>
+      {renderAdminButton()}
       <div className="translation-header">
         <div className="col">
         {
@@ -78,7 +98,7 @@ function TranslationContent({ context }) {
               <div className='col'>
                 <strong>
                   {
-                    baseCourses[baseCourse].language ? 
+                    baseCourses[baseCourse].language ?
                     context.LANGUAGES[baseCourses[baseCourse].language] :
                     'NA'
                   }
@@ -87,7 +107,7 @@ function TranslationContent({ context }) {
               <div className='col'>
                 <strong>
                   {
-                    rerunCourses[rerunCourse].language ? 
+                    rerunCourses[rerunCourse].language ?
                     context.LANGUAGES[rerunCourses[rerunCourse].language] :
                     'NA'
                   }
@@ -95,7 +115,7 @@ function TranslationContent({ context }) {
               </div>
             </div>
             {
-              !isEmpty(courseOutline.base_course_outline) && 
+              !isEmpty(courseOutline.base_course_outline) &&
               <Sections
                   context={context}
                   setLoading={setLoading}
@@ -110,7 +130,7 @@ function TranslationContent({ context }) {
                 No Translations Found!, Please apply mapping.
               </p>
             }
-            
+
           </Fragment>
         )
       }

--- a/openedx/features/wikimedia_features/meta_translations/static/translations/js/hooks/useFetch.js
+++ b/openedx/features/wikimedia_features/meta_translations/static/translations/js/hooks/useFetch.js
@@ -5,9 +5,13 @@ import useClient from "./useClient";
 export default function useFetch(context) {
     const { client, notification } = useClient();
 
-    const fetchCourses = (setCourses, setLoading) => {
+    const fetchCourses = (setCourses, setLoading, only_admin_created_courses=false) => {
       setLoading(true);
-      client.get(context.COURSES_URL)
+      let url = context.COURSES_URL
+      if(only_admin_created_courses){
+        url = `${url}?admin_created_courses=True`
+      }
+      client.get(url)
       .then((res) => {
         setCourses(res.data);
       })

--- a/openedx/features/wikimedia_features/meta_translations/templates/translations.html
+++ b/openedx/features/wikimedia_features/meta_translations/templates/translations.html
@@ -25,7 +25,8 @@
             "COURSE_OUTLINE_URL": "api/v0/outline",
             "COURSE_UNIT_URL": "api/v0/components",
             "COURSE_APPROVE_URL": "api/v0",
-            "LANGUAGES": ${language_options | n, dump_js_escaped_json}
+            "LANGUAGES": ${language_options | n, dump_js_escaped_json},
+            "IS_ADMIN": "${is_admin}"
         }
 
         new Translations(context);

--- a/openedx/features/wikimedia_features/meta_translations/views.py
+++ b/openedx/features/wikimedia_features/meta_translations/views.py
@@ -39,6 +39,7 @@ def render_translation_home(request):
         'uses_bootstrap': True,
         'login_user_username': request.user.username,
         'language_options': dict(settings.ALL_LANGUAGES),
+        'is_admin': request.user.is_superuser
     })
 
 @login_required

--- a/package-lock.json
+++ b/package-lock.json
@@ -12417,6 +12417,14 @@
         "slick-carousel": "^1.6.0"
       }
     },
+    "react-switch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-6.0.0.tgz",
+      "integrity": "sha512-QV3/6eRK5/5epdQzIqvDAHRoGLbCv/wDpHUi6yBMXY1Xco5XGuIZxvB49PHoV1v/SpEgOCJLD/Zo43iic+aEIw==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-test-renderer": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-redux": "5.0.7",
     "react-router-dom": "5.1.2",
     "react-slick": "0.16.0",
+    "react-switch": "^6.0.0",
     "react-toastify": "^8.0.2",
     "redux": "3.7.2",
     "redux-thunk": "2.2.0",


### PR DESCRIPTION
- Add a special button for Admin on meta_transaltion page to filter only my courses in dropdown instead of just “all courses” list.
- Styling will be fixed in seperate PR