### PR TITLE
Add revert call back for course level flag update

### DIFF
--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -312,7 +312,10 @@ define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui'
                        this.model.set('self_paced', JSON.parse(event.currentTarget.value));
                        break;
                    case 'is-destination-course':
-                       WikiUtils.showMsgOnCourseFlagSettingUpdate(_.bind(this.updateCourseFlag, this))
+                       WikiUtils.showMsgOnCourseFlagSettingUpdate(
+                           _.bind(this.updateCourseFlag, this),
+                           _.bind(this.revertView, this)
+                        )
                        break;
                    case 'course-language':
                    case 'course-effort':

--- a/cms/static/js/views/utils/wiki_utils.js
+++ b/cms/static/js/views/utils/wiki_utils.js
@@ -78,7 +78,7 @@
         );
     };
 
-    showMsgOnCourseFlagSettingUpdate = function(operation) {
+    showMsgOnCourseFlagSettingUpdate = function(operation, onCancelCallback) {
         ViewUtils.confirmThenRunOperation(
             StringUtils.interpolate(
                 gettext('Change can not be reverted.'),
@@ -89,7 +89,8 @@
                 gettext('Yes, Update Flag'),
                 true
             ),
-            operation
+            operation,
+            onCancelCallback
         );
     };
 


### PR DESCRIPTION
**Bug reported:**
- Update Course Level flag -> Check (True) to Uncheck (False)
- Warning will be shown.
- Click on Cancel button of warning.
- Updates changes still shown on front-end -> user has to update browser to view changes.

**Fix:**
Add revert front-end changes call back on cancel button click.