### PR TITLE
Add checks in tranlsated rerun creation and show relevant errors

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -321,7 +321,8 @@ def course_rerun_handler(request, course_key_string):
                 'display_name': course_module.display_name,
                 'user': request.user,
                 'course_creator_status': _get_course_creator_status(request.user),
-                'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False)
+                'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
+                'is_translated_rerun': CourseTranslation.is_base_or_translated_course(course_key).upper() == "TRANSLATED"
             })
 
 
@@ -331,6 +332,7 @@ def course_rerun_handler(request, course_key_string):
 def course_search_index_handler(request, course_key_string):
     """
     The restful handler for course indexing.
+
     GET
         html: return status of indexing task
         json: return status of indexing task
@@ -870,7 +872,7 @@ def _create_or_rerun_course(request):
 
     try:
         # meta-translation feature, to identify type of rerun
-        is_basic_rerun = request.json.get('basic_rerun')
+        is_translated_rerun = request.json.get('translated_rerun')
         language = request.json.get('language')
         org = request.json.get('org')
         course = request.json.get('number', request.json.get('course'))
@@ -878,12 +880,32 @@ def _create_or_rerun_course(request):
         # force the start date for reruns and allow us to override start via the client
         start = request.json.get('start', CourseFields.start.default)
         run = request.json.get('run')
+        source_course_key = request.json.get('source_course_key')
 
         # allow/disable unicode characters in course_id according to settings
         if not settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID'):
             if _has_non_ascii_characters(org) or _has_non_ascii_characters(course) or _has_non_ascii_characters(run):
                 return JsonResponse(
                     {'error': _('Special characters not allowed in organization, course number, and course run.')},
+                    status=400
+                )
+
+        if is_translated_rerun:
+            if not language:
+                return JsonResponse(
+                    {'error': _('Course Language is required field for Translated rerun.')},
+                    status=400
+                )
+            elif CourseTranslation.is_translated_rerun_exists_in_language(source_course_key, language):
+                return JsonResponse(
+                    {'error': _('Translated rerun for Source Course in selected language already exists.')},
+                    status=400
+                )
+
+            source_course_details = CourseDetails.fetch(CourseKey.from_string(source_course_key))
+            if not source_course_details or not source_course_details.source_course_language:
+                return JsonResponse(
+                    {'error': _('Translated rerun can not be created for the base course with no language. Please set base course language from settings.')},
                     status=400
                 )
 
@@ -901,11 +923,10 @@ def _create_or_rerun_course(request):
         definition_data = {'wiki_slug': wiki_slug}
         fields.update(definition_data)
 
-        source_course_key = request.json.get('source_course_key')
         if source_course_key:
             source_course_key = CourseKey.from_string(source_course_key)
             destination_course_key = rerun_course(request.user, source_course_key, org, course, run, fields)
-            if not is_basic_rerun:
+            if is_translated_rerun:
                 CourseTranslation.set_course_translation(destination_course_key, source_course_key)
                 course_blocks_mapping(destination_course_key)
             return JsonResponse({

--- a/cms/static/js/views/course_rerun.js
+++ b/cms/static/js/views/course_rerun.js
@@ -45,10 +45,10 @@ define(['domReady', 'jquery', 'underscore', 'js/views/utils/create_course_utils'
                 number: number,
                 display_name: display_name,
                 run: run,
-                basic_rerun: rerun_type=="basic" ? true : false
+                translated_rerun: rerun_type=="translated" ? true : false
             };
 
-            if (rerun_type != 'basic'){
+            if (rerun_type == 'translated'){
                 courseInfo.language = language
             }
 
@@ -97,7 +97,8 @@ define(['domReady', 'jquery', 'underscore', 'js/views/utils/create_course_utils'
                     languageFilter.slideDown()
                 ;
             });
-
+            $("#basic-rerun").prop("checked", true);
+            languageFilter.slideUp();
             CreateCourseUtils.configureHandlers();
         };
 

--- a/openedx/features/wikimedia_features/meta_translations/models.py
+++ b/openedx/features/wikimedia_features/meta_translations/models.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
+from lms.djangoapps.courseware.courses import get_course_by_id
 
 log = logging.getLogger(__name__)
 User = get_user_model()
@@ -474,6 +475,17 @@ class CourseTranslation(models.Model):
         """
         return CourseTranslation.objects.filter(base_course_id=course_id).exists()
 
+    @classmethod
+    def is_translated_rerun_exists_in_language(cls, base_course_id, language):
+        """
+        Returns boolean value indicating if translated rerun in language already exists for given base course id.
+        """
+        translated_reruns_linkage = CourseTranslation.objects.filter(base_course_id=base_course_id)
+        for linkage in translated_reruns_linkage:
+            translated_rerun_course = get_course_by_id(linkage.course_id)
+            if translated_rerun_course and translated_rerun_course.language==language:
+                return True
+        return False
 
     class Meta:
         app_label = APP_LABEL


### PR DESCRIPTION
## Description
- Translated rerun should not allow further translated rerun creation.
- Add some validations on translated rerun creations and show error msgs to user:
    - if language is not selected.
![image](https://user-images.githubusercontent.com/42185078/175262205-cd628126-2d3a-4922-aa81-501eafac6620.png)

    - if translated rerun already exists in the selected course language.
![image](https://user-images.githubusercontent.com/42185078/175262433-7ea72a9c-336c-42d5-b543-c8f89d6e3def.png)
 
    - if base course language is not set.
![image](https://user-images.githubusercontent.com/42185078/175300344-56ec0e9c-0191-418b-9d1e-a552ad2959d6.png)


 ## Related theme PR
https://github.com/wikimedia/wikilearn-edx-theme/pull/38