### PR TITLE
Bug fix - update send api call to send all data blocks if any data block is updated

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/management/commands/sync_untranslated_strings_to_meta_from_edx.py
+++ b/openedx/features/wikimedia_features/meta_translations/management/commands/sync_untranslated_strings_to_meta_from_edx.py
@@ -115,12 +115,10 @@ class Command(BaseCommand):
             )
             for block in base_course_blocks:
                 if block.block_type != 'course':
-                    updated_block_data = block.courseblockdata_set.filter(
-                        Q(content_updated=True) | Q(mapping_updated=True)
-                    )
-                    if updated_block_data.exists():
+                    block_data = block.courseblockdata_set.all()
+                    if block_data.filter(Q(content_updated=True) | Q(mapping_updated=True)).exists():
                         request_arguments = self._create_request_dict_for_block(base_course, block, base_course_language)
-                        for data in updated_block_data:
+                        for data in block_data:
                             if data.parsed_keys:
                                 request_arguments.update(data.parsed_keys)
                             else:


### PR DESCRIPTION
## Backgroud
Blocks can have multiple data i.e problem will have display_name and content. For each block, there will be a translation page on meta server.

For problem block, there will be a meta server page with the following content
{
"display_name" : "mcq test",
"content": "sample content"
}

On every fetch call, the meta server overwrites the full page.


### Bug:
Previously we were just sending updated data to the meta server i.e if disply_name is updated then just send display_name and do not send content again as a result of which page on metaserver was overwriting as follows:
{
"display_name" : "mcq test",
}

### Solution 
we have to send all data again even if single data is updated.