### PR TITLE
Fix itemnotfound rerun task error

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -75,7 +75,6 @@ from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 from openedx.features.course_experience.waffle import waffle as course_experience_waffle
 from openedx.features.wikimedia_features.meta_translations.utils import update_course_to_source, is_destination_course
-from openedx.features.wikimedia_features.meta_translations.mapping.utils import course_blocks_mapping
 from openedx.features.wikimedia_features.meta_translations.models import MetaTranslationConfiguration
 from xmodule.contentstore.content import StaticContent
 from xmodule.course_module import DEFAULT_START_DATE, CourseFields
@@ -925,15 +924,9 @@ def _create_or_rerun_course(request):
         fields.update(definition_data)
 
         if source_course_key:
+            fields['is_translated_rerun'] = is_translated_rerun
             source_course_key = CourseKey.from_string(source_course_key)
             destination_course_key = rerun_course(request.user, source_course_key, org, course, run, fields)
-            if is_translated_rerun:
-                CourseTranslation.set_course_translation(destination_course_key, source_course_key)
-                course_blocks_mapping(destination_course_key)
-                course_module = modulestore().get_course(destination_course_key)
-                if course_module:
-                    course_module.language = language
-                    modulestore().update_item(course_module, request.user.id)
             return JsonResponse({
                 'url': reverse_url('course_handler'),
                 'destination_course_key': str(destination_course_key)


### PR DESCRIPTION
## Bug
```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 412, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 704, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 179, in new_function
    return wrapped_function(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/tasks.py", line 159, in rerun_course
    CourseRerunState.objects.failed(course_key=destination_course_key)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/course_action_state/managers.py", line 145, in failed
    self.update_state(
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/course_action_state/managers.py", line 76, in update_state
    raise CourseActionStateItemNotFoundError(
```

## Result of R&D:
- We tried to access course while the course-rerun creation task is still in progress.
- In ` course_blocks_mapping(destination_course_key)` method we were trying to retrieve course from modulestore which was raising the CourseNotFound Exception as rerun-task wasn't completed at that time as a result -> rerun task raised above error. 

## Solution:
- To make sure that course task is completed and then we run our mapping funciton -> We moved our changes inside task.