### PR TITLE
Make studio header same as LMS

### DIFF
--- a/openedx/features/wikimedia_features/messenger/templates/messenger.html
+++ b/openedx/features/wikimedia_features/messenger/templates/messenger.html
@@ -16,6 +16,9 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
 
 <%block name="head_extra">
     <link rel="stylesheet" type="text/css" href="/static/css/ReactToastify.css" />
+    <link type="text/css" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="${static.url('css/bootstrap/lms-main.css')}" type="text/css" media="all" />
 </%block>
 <%block name="htmlclass">messenger-root</%block>
 <%block name="bodyclass">messenger-dashboard</%block>


### PR DESCRIPTION
## Make studio header same as LMS

Bootstrap assets move to messenger page.