### PR TITLE
Rename courseware tabs

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -103,7 +103,7 @@ class ProgressTab(EnrolledTab):
     The course progress view.
     """
     type = 'progress'
-    title = gettext_noop('Progress')
+    title = gettext_noop('Score')
     priority = 40
     view_name = 'progress'
     is_hideable = True

--- a/openedx/features/wikimedia_features/wikimedia_general/tab.py
+++ b/openedx/features/wikimedia_features/wikimedia_general/tab.py
@@ -8,7 +8,7 @@ from xmodule.tabs import TabFragmentViewMixin
 
 class WikimediaProgressTab(TabFragmentViewMixin, EnrolledTab):
     type = 'wikimedia_progress_tab'
-    title = ugettext_noop('Wiki Progress')
+    title = ugettext_noop('Progress')
     priority = None
     fragment_view_name = 'openedx.features.wikimedia_features.wikimedia_general.views.WikimediaProgressFragmentView'
     is_hideable = False


### PR DESCRIPTION
Changes course tabs: "Progress" and "Wiki Progress" to "Score" and "Progress" respectively.