### PR TITLE
Add a task to send course strings to the Meta Server after every translated rerun

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/mapping/utils.py
+++ b/openedx/features/wikimedia_features/meta_translations/mapping/utils.py
@@ -7,6 +7,7 @@ from logging import getLogger
 from lxml import etree
 from django.conf import settings
 
+from openedx.features.wikimedia_features.meta_translations.tasks import send_untranslated_strings_to_meta_from_edx_task
 from openedx.features.wikimedia_features.meta_translations.wiki_components import COMPONENTS_CLASS_MAPPING
 from openedx.features.wikimedia_features.meta_translations.models import (
     CourseBlock, CourseBlockData, CourseTranslation, WikiTranslation
@@ -259,6 +260,8 @@ def course_blocks_mapping(course_key):
     For base-course: run mapping just on course.
     For translated-rerun course: run mapping on base course then run mapping on translated-rerun course
     For Normal course or rerun: Log message and skip mapping call.
+    ...
+    For every translated rerun: send course strings to the Meta Server
     """
     def map_base_course(base_course_key):
         base_course = get_course_by_id(base_course_key)
@@ -291,4 +294,5 @@ def course_blocks_mapping(course_key):
     else:
         map_base_course(base_course_key)
         map_translated_version(base_course_key, course_key)
+        send_untranslated_strings_to_meta_from_edx_task.delay(str(base_course_key))
         return True

--- a/openedx/features/wikimedia_features/meta_translations/tasks.py
+++ b/openedx/features/wikimedia_features/meta_translations/tasks.py
@@ -1,0 +1,28 @@
+"""
+Meta Transaltions related tasks
+"""
+from django.core import management
+from logging import getLogger
+
+from celery import task
+from celery_utils.logged_task import LoggedTask
+
+log = getLogger(__name__)
+
+@task(base=LoggedTask)
+def send_untranslated_strings_to_meta_from_edx_task(base_course_key):
+    """
+    Args:
+        base_course_key (CourseKey): Base course key
+    """
+    log.info(f"Initiated task to sync course: {base_course_key} translations to the Meta Server")
+
+    try:
+        management.call_command(
+            'sync_untranslated_strings_to_meta_from_edx',
+            commit=True,
+            base_course_key=base_course_key,
+        )
+        log.info(f'Base Course: {base_course_key} stirngs are updated successfully')
+    except Exception as error:
+        log.error(f'Error occured in the management command: {str(error)}')


### PR DESCRIPTION
This PR is used with the maple release, a copy of https://github.com/wikimedia/edx-platform/commit/33e1cb9516a6d8f858d909709e10aa8ef218df05 PR, which was used with lilac release.