### PR TITLE
fix: search substring in discover courses

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/static/discover_courses/js/components/DiscoverCoursesContent.js
+++ b/openedx/features/wikimedia_features/meta_translations/static/discover_courses/js/components/DiscoverCoursesContent.js
@@ -28,7 +28,7 @@ function DiscoverCoursesContent({ context }) {
     return (
       (toLanguge.value == '' || toLanguge.value == course.course_lang) &&
       (fromLanguge.value == '' || fromLanguge.value == course.base_course_lang) &&
-      (searchCourse == '' || course.base_course_name.toLowerCase().startsWith(searchCourse.toLowerCase()))
+      (searchCourse == '' || course.base_course_name.toLowerCase().includes(searchCourse.toLowerCase()))
     )
   }
 


### PR DESCRIPTION
Search for substring instead of starts with in discover courses.