### PR TITLE
Mark edits as bot edits

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/meta_client.py
+++ b/openedx/features/wikimedia_features/meta_translations/meta_client.py
@@ -242,6 +242,7 @@ class WikiMetaClient(object):
             "summary": summary,
             "contentmodel": self._CONTENT_MODEL,
             "token": csrf_token,
+            "bot": 1,
         }
 
         success, response_data = await self.handle_request(session.post, params=None, data=data)


### PR DESCRIPTION
Mark edits as bot edits. Without this parameter, edits appear in Recent Changes even if the user has bot status.

## Supporting information

- https://meta.wikimedia.org/wiki/User_talk:WikiLearnBot#Bot_flag_not_applied_to_edits_/_page_creations

## Testing instructions

Check whether WikiLearnBot's edits on metawiki appear in Special:RecentChanges or not. You can also check by adding a page it has recently added to your watchlist, and see if the edit appears there.

## Deadline

Would be nice to get this done quickly, since the bot is currently polluting recent changes on metawiki.
