### PR TITLE
Fix add gitpython requirement for prod

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -534,6 +534,8 @@ geoip2==4.4.0
     # via -r requirements/edx/base.in
 glob2==0.7
     # via -r requirements/edx/base.in
+gitpython==3.1.24
+    # this is a requirement for edx-sysadmin.
 gunicorn==20.1.0
     # via -r requirements/edx/base.in
 help-tokens==2.1.0


### PR DESCRIPTION
This adds gitpython requirement to be installed for production as well. Git python is a requirement  for edx_sysadmin.