### PR TITLE
feat: update share alike license text

### DIFF
--- a/cms/templates/js/license-selector.underscore
+++ b/cms/templates/js/license-selector.underscore
@@ -102,7 +102,11 @@
                 <% _.each(enabled, function(option) { %>
                         <span class="sr"><%- license.options[option.toUpperCase()].name %>&nbsp;</span><span aria-hidden="true" class="icon-cc-<%- option %>"></span>
                 <% }); %>
-                <span class="license-text"><%- gettext("Some Rights Reserved") %></span>
+                <% if (enabled.includes('sa')) {%>
+                    <span class="license-text"><%- gettext(`CC-by-sa ${version}`) %></span>
+                <%} else {%>
+                    <span class="license-text"><%- gettext("Some Rights Reserved") %></span>
+                <% } %>
             <% } %>
         <% } else { %>
             <%- typeof licenseString == "string" ? licenseString : "" %>


### PR DESCRIPTION
Update license text to say "CC-by-sa" when `creative common` license is selected with `share alike` option