### PR TITLE
fix: build error caused by removed py2neo package

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -724,10 +724,6 @@ psutil==5.8.0
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
-py2neo==2021.2.3
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.in
 pycountry==20.7.3
     # via -r requirements/edx/base.in
 pycparser==2.20
@@ -1078,6 +1074,7 @@ edx-sysadmin                        # External requirements
 pomerge                             # Used in the localization feature
 git+https://github.com/wikimedia/edx-ora2.git@wm-v1.0#egg=ora2
 git+https://github.com/edly-io/xblock-sortable.git@v0.1#egg=sortable-xblock
+git+https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -990,10 +990,6 @@ py==1.10.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/testing.txt
 pycodestyle==2.8.0
     # via -r requirements/edx/testing.txt
 pycountry==20.7.3
@@ -1566,6 +1562,7 @@ edx-sysadmin                        # External requirements
 pomerge                             # Used in the localization feature
 git+https://github.com/wikimedia/edx-ora2.git@wm-v1.0#egg=ora2
 git+https://github.com/edly-io/xblock-sortable.git@v0.1#egg=sortable-xblock
+git+https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -930,10 +930,6 @@ py==1.10.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
-    # via
-    #   -c requirements/edx/../constraints.txt
-    #   -r requirements/edx/base.txt
 pycodestyle==2.8.0
     # via -r requirements/edx/testing.in
 pycountry==20.7.3


### PR DESCRIPTION
On Oct. 10, py2neo package was abruptly removed from pypi, GitHub, so we install it from openedx's fork.