### PR TITLE
fix: hide courses from home page with display set to none

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -724,6 +724,8 @@ def get_courses(user, org=None, filter_=None, permissions=None):
         settings.COURSE_CATALOG_VISIBILITY_PERMISSION
     )
     permissions.add(permission_name)
+    
+    courses = courses.exclude(catalog_visibility="none")
 
     return LazySequence(
         (c for c in courses if all(has_access(user, p, c) for p in permissions)),


### PR DESCRIPTION
Filters out courses from lms home page with catalog visibility set to "none".
These courses were cached so we might need to hard reload the browser page to see changes.
