### PR TITLE
fix: django-require install url

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -316,7 +316,7 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
 django-ratelimit-backend @ git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e
     # via -r requirements/edx/github.in
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
+django-require @ git+https://github.com/openedx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
     # via -r requirements/edx/github.in
 django-sekizai==2.0.0
     # via


### PR DESCRIPTION
Since Edx changed their name to OpenEdx and consequently moved many of their repos. We have to update install urls as well.

More detail can be found here:
https://discuss.openedx.org/t/please-update-your-git-urls-for-edx-platform-and-several-other-repos/12387