### PR TITLE
feat: add start date to all courses admin report

### DIFF
--- a/openedx/features/wikimedia_features/admin_dashboard/admin_task/api.py
+++ b/openedx/features/wikimedia_features/admin_dashboard/admin_task/api.py
@@ -170,7 +170,8 @@ def all_courses_enrollment_report(request):
     query_features = [
         "course_url",
         "course_title",
-        "available_since",
+        "start_date",
+        "enrollment_date",
         "archived_date",
         "parent_course_url",
         "parent_course_title",

--- a/openedx/features/wikimedia_features/admin_dashboard/course_versions/task_helper.py
+++ b/openedx/features/wikimedia_features/admin_dashboard/course_versions/task_helper.py
@@ -135,7 +135,7 @@ def upload_all_courses_enrollment_csv(
     csv_type = task_input.get("csv_type", "all_enrollments_stats")
 
     query_features_names = [
-        'Course URL', 'Course title', 'Course available since', 'Course Archived Date', 'Parent course URL', 'Parent course title', 'Total learners enrolled', 'Total learners completed', 'Percentage of learners who completed the course', 'Certificates Generated',
+        'Course URL', 'Course title', 'Start Date', 'Enrollment Date', 'Course Archived Date', 'Parent course URL', 'Parent course title', 'Total learners enrolled', 'Total learners completed', 'Percentage of learners who completed the course', 'Certificates Generated',
     ]
     data = list_all_courses_enrollment_data()
 

--- a/openedx/features/wikimedia_features/admin_dashboard/course_versions/utils.py
+++ b/openedx/features/wikimedia_features/admin_dashboard/course_versions/utils.py
@@ -267,7 +267,8 @@ def list_all_courses_enrollment_data():
         courses_data.append({
             "course_url": get_cms_course_url(str(course.id)),
             "course_title": course.display_name,
-            "available_since": course.enrollment_start.strftime("%Y-%m-%d") if course.enrollment_start else '',
+            "start_date": course.start.strftime("%Y-%m-%d") if course.start else '',
+            "enrollment_date": course.enrollment_start.strftime("%Y-%m-%d") if course.enrollment_start else '',
             "archived_date": course.end.strftime("%Y-%m-%d") if course.has_ended() else '',
             "parent_course_url": parent_course_url,
             "parent_course_title": parent_course_title,


### PR DESCRIPTION
The column "Course available since" was confusing. This PR renames that column to "Enrollment date" and adds a new column for the start date.