### PR TITLE
fix: normalize language codes when using MetaWiki API

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/management/commands/sync_translated_strings_to_edx_from_meta.py
+++ b/openedx/features/wikimedia_features/meta_translations/management/commands/sync_translated_strings_to_edx_from_meta.py
@@ -127,8 +127,12 @@ class Command(BaseCommand):
             target_block = translation_obj.target_block
             source_block_key = str(source_block.block_id)
             if not target_block.is_source():
-                target_language = get_course_by_id(target_block.course_id).language
-                source_language = get_course_by_id(source_block.course_id).language
+                target_language = WikiMetaClient.normalize_language_code(
+                    get_course_by_id(target_block.course_id).language
+                )
+                source_language = WikiMetaClient.normalize_language_code(
+                    get_course_by_id(source_block.course_id).language
+                )
                 if source_block_key in data_dict:
                     data_dict[source_block_key]["target_block_versions"][target_language] = str(target_block.block_id)
                 else:
@@ -398,13 +402,13 @@ class Command(BaseCommand):
                 if block.translated != is_translated:
                     block.translated = is_block_translated(block)
                     block.save()
-                    
+
                     log.info(
                         "CourseBlock translated status have been updated for block_id {} translated: {}".format(
                             block.block_id, is_translated,
                         )
                     )
-    
+
     def update_info(self):
         """
         Adds entry to MetaCronJobInfo
@@ -414,7 +418,7 @@ class Command(BaseCommand):
             MetaCronJobInfo.objects.create(fetched_date = datetime.now(), sent_date = latest_info.sent_date)
         except MetaCronJobInfo.DoesNotExist:
             MetaCronJobInfo.objects.create(fetched_date = datetime.now())
-            
+
     def handle(self, *args, **options):
         data_dict = self._get_request_data_dict()
 

--- a/openedx/features/wikimedia_features/meta_translations/management/commands/sync_untranslated_strings_to_meta_from_edx.py
+++ b/openedx/features/wikimedia_features/meta_translations/management/commands/sync_untranslated_strings_to_meta_from_edx.py
@@ -68,12 +68,6 @@ class Command(BaseCommand):
         log.info('Total number of updated blocks: {}'.format(self._RESULT.get("updated_blocks_count")))
         log.info('Total blocks updated successfully: {}'.format(self._RESULT.get("success_updated_pages_count")))
 
-    def normalize_language_code(self, languages):
-        """
-        Meta Wiki does not support '_' in language code.
-        """
-        return [lang.replace('_', '-').lower() for lang in languages]
-
     def _create_request_dict_for_block(self, base_course, block, block_data, base_course_language, base_course_name, base_course_description):
         """
         Returns request dict required for update pages API of Wiki Meta
@@ -102,12 +96,9 @@ class Command(BaseCommand):
             base_course_name, get_studio_component_name(block.block_type), block_data.filter(data_type="display_name")[0].data
         )
 
-        original_priority_languages = json.loads(block.lang)
-        normalized_priority_languages = self.normalize_language_code(original_priority_languages)
-
         request["@metadata"] = {
             "sourceLanguage": base_course_language,
-            "priorityLanguages": normalized_priority_languages,
+            "priorityLanguages": [WikiMetaClient.normalize_language_code(lang) for lang in json.loads(block.lang)],
             "allowOnlyPriorityLanguages": True,
             "description": description,
             "label": label

--- a/openedx/features/wikimedia_features/meta_translations/management/commands/sync_untranslated_strings_to_meta_from_edx.py
+++ b/openedx/features/wikimedia_features/meta_translations/management/commands/sync_untranslated_strings_to_meta_from_edx.py
@@ -68,6 +68,12 @@ class Command(BaseCommand):
         log.info('Total number of updated blocks: {}'.format(self._RESULT.get("updated_blocks_count")))
         log.info('Total blocks updated successfully: {}'.format(self._RESULT.get("success_updated_pages_count")))
 
+    def normalize_language_code(self, languages):
+        """
+        Meta Wiki does not support '_' in language code.
+        """
+        return [lang.replace('_', '-').lower() for lang in languages]
+
     def _create_request_dict_for_block(self, base_course, block, block_data, base_course_language, base_course_name, base_course_description):
         """
         Returns request dict required for update pages API of Wiki Meta
@@ -96,9 +102,12 @@ class Command(BaseCommand):
             base_course_name, get_studio_component_name(block.block_type), block_data.filter(data_type="display_name")[0].data
         )
 
+        original_priority_languages = json.loads(block.lang)
+        normalized_priority_languages = self.normalize_language_code(original_priority_languages)
+
         request["@metadata"] = {
             "sourceLanguage": base_course_language,
-            "priorityLanguages": json.loads(block.lang),
+            "priorityLanguages": normalized_priority_languages,
             "allowOnlyPriorityLanguages": True,
             "description": description,
             "label": label

--- a/openedx/features/wikimedia_features/meta_translations/meta_client.py
+++ b/openedx/features/wikimedia_features/meta_translations/meta_client.py
@@ -69,13 +69,20 @@ class WikiMetaClient(object):
         if title:
             return "{}/{}".format(self._BASE_REDIRECT_URL, title)
 
+    @staticmethod
+    def normalize_language_code(language_code):
+        """
+        This is because meta api expects hyphen instead of underscore.
+        """
+        return language_code.replace('_', '-').lower()
+
     def get_expected_message_group_redirect_url(self, source_page_title, target_language):
         """
         Returns expected redirect url of meta server from where user can translate content.
         Term "expected" is used as we are not sure if message groups for translation have been created or not.
         """
         url = "{}/Special:Translate?group={}-{}&language={}".format(
-            self._BASE_REDIRECT_URL, self._MCGROUP_PREFIX, urllib.parse.quote(source_page_title), target_language
+            self._BASE_REDIRECT_URL, self._MCGROUP_PREFIX, urllib.parse.quote(source_page_title), WikiMetaClient.normalize_language_code(target_language)
         )
         return url
 


### PR DESCRIPTION
Replaces '_' with '-' in priority languages and lowercase them for MetaWiki.

## Context
Our send translation cronjob was failing because Chinese varients had language code like "zh-hans", while MetaWiki only accepts codes with '_'.

Closes: https://github.com/wikimedia/edx-platform/issues/483