### PR TITLE
ci: update deprecated ubuntu version from 20.04 to latest

### DIFF
--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   generate-translations:
     name: Detect changed source and generate Transifex and Translatewiki translations
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
The [generate-translations](https://github.com/wikimedia/edx-platform/blob/develop/.github/workflows/generate-translations.yml) workflow is currently [failing](https://github.com/wikimedia/edx-platform/actions/runs/14858329167/job/41716819652). This is because of the following error:

```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```

We update the ubuntu version from `ubuntu-20.04` to `ubuntu-latest`. This way, we do not need to update the version again and again when there is another deprecation.