### PR TITLE
ci: update base branch to develop for generated translations workflow

### DIFF
--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -171,6 +171,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           branch: 'gitflow/auto-generated-translations'
+          base: develop
           commit-message: 'Add changed translation files'
           add-paths: |
             conf/locale/**/LC_MESSAGES/wm-django.po


### PR DESCRIPTION
The `generate-translations.yml` workflow in the `wm/localization` branch always fails at the end because it tries to create a branch against `wm/localization` as the base but a PR against that branch always exists in #384.