### PR TITLE
ci: automate workflow to run on the first Monday of each month

### DIFF
--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -171,6 +171,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           branch: 'gitflow/auto-generated-translations'
+          base: develop
           commit-message: 'Add changed translation files'
           add-paths: |
             conf/locale/**/LC_MESSAGES/wm-django.po

--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   generate-translations:
     name: Detect changed source and generate Transifex and Translatewiki translations
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -8,8 +8,14 @@ on:
         required: false
         default: 'develop'
 
+  # Scheduled trigger: first Monday of every month at 7AM (UTC) or 12PM (PKT)
+  schedule:
+    - cron: "0 7 1-7 * 1"
+
 jobs:
   generate-translations:
+    # Only run on the wm/localization branch
+    if: github.ref == 'refs/heads/wm/localization'
     name: Detect changed source and generate Transifex and Translatewiki translations
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -50,12 +56,12 @@ jobs:
           ref: ${{ inputs.theme_branch }}
           token: ${{ secrets.THEME_ACCESS_TOKEN }}
 
-      - name: Checkout master as feature branch does not exist
+      - name: Checkout develop branch as feature branch does not exist
         uses: actions/checkout@v3
         with:
           repository: wikimedia/wikilearn-edx-theme
           path: ./themes
-          ref: master
+          ref: develop
           token: ${{ secrets.THEME_ACCESS_TOKEN }}
         if: steps.clone-theme-repo.outcome == 'failure'
 


### PR DESCRIPTION
fixes #487.

**Changes**

- #485 
- #486 
- We now automate this workflow to run from the `wm/localization` branch on the first Monday of each month at 7AM (UTC) or 12PM (Pakistan Time). Previously, we had to run this workflow manually which was very inefficient. 

There is no way to set the theme_branch for the scheduled workflow but we have a failsafe in the workflow for that scenario anyway so it will default to `develop` anyway