### PR TITLE
ci: Run workflow on 1st day of every month

### DIFF
--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -8,9 +8,9 @@ on:
         required: false
         default: 'develop'
 
-  # Scheduled trigger: first Monday of every month at 7AM (UTC) or 12PM (PKT)
+  # Scheduled trigger: first day of every month at 7AM (UTC) or 12PM (PKT)
   schedule:
-    - cron: "0 7 1-7 * 1"
+    - cron: "0 7 1 * *"
 
 jobs:
   generate-translations:


### PR DESCRIPTION
The current cronjob doesn't run if the monday doesn't fall on the 1st day of the month.

We now change it to run on the 1st day of the month regardless of whatever day it is.