### PR TITLE
ci: checkout wm/localization branch when running generate-translations workflow

### DIFF
--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -14,8 +14,6 @@ on:
 
 jobs:
   generate-translations:
-    # Only run on the wm/localization branch
-    if: github.ref == 'refs/heads/wm/localization'
     name: Detect changed source and generate Transifex and Translatewiki translations
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -23,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: wm/localization
 
       - name: Set up python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes #500.

The workflow still runs on the base branch (develop), however we checkout the wm/localization branch instead now to integrate the localization changes made in that branch.