### PR TITLE
fix: add User-Agent header to authentication API calls

### DIFF
--- a/openedx/features/wikimedia_features/auth_backend.py
+++ b/openedx/features/wikimedia_features/auth_backend.py
@@ -1,5 +1,6 @@
 import logging
 from django.utils.functional import cached_property
+from django.conf import settings
 from social_core.exceptions import AuthException
 from common.djangoapps.third_party_auth.identityserver3 import IdentityServer3
 
@@ -24,6 +25,15 @@ class WikimediaIdentityServer(IdentityServer3):
         # Truncate the firstname to max 30 characters. User model doesn't accepts firstname above 30 characters.
         firstname = firstname if len(firstname)<=30 else firstname[:30]
         return fullname, firstname, lastname
+
+    def auth_headers(self):
+        headers = super().auth_headers()
+        client = getattr(settings, "PLATFORM_NAME", "wikilearn")
+        site = getattr(settings, "LMS_ROOT_URL", "https://learn.wiki/")
+        contact_mail = getattr(settings, "CONTACT_EMAIL", "comdevteam@wikimedia.org")
+        headers['User-Agent'] = f'{client}/0.13 ({site}; {contact_mail})'
+        
+        return headers
 
     def get_user_details(self, response):
         """


### PR DESCRIPTION
This is being done for compatibility with the Wikimedia Foundation User-Agent Policy
The policy can be found at: https://foundation.m.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy

