### PR TITLE
fix: update wikimeta's url used for testing

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2515,7 +2515,7 @@ WIKI_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-runni
 CUSTOM_PAGES_HELP_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#adding-custom-pages"
 
 ################### Settings for wiki meta translations ##############
-WIKI_META_BASE_API_URL = "https://language-mleb-master.wmcloud.org/api.php"
+WIKI_META_BASE_API_URL = "https://lpl-mleb-master.wmcloud.org/api.php"
 WIKI_META_CONTENT_MODEL = "translate-messagebundle"
 WIKI_META_MCGROUP_PREFIX = "messagebundle"
 WIKI_META_API_USERNAME = ""

--- a/openedx/features/wikimedia_features/meta_translations/settings/common.py
+++ b/openedx/features/wikimedia_features/meta_translations/settings/common.py
@@ -28,8 +28,8 @@ def plugin_settings(settings):
       'stringresponse',
     ]
 
-    settings.WIKI_META_BASE_URL = "https://language-mleb-master.wmcloud.org/index.php"
-    settings.WIKI_META_BASE_API_URL = "https://language-mleb-master.wmcloud.org/api.php"
+    settings.WIKI_META_BASE_URL = "https://lpl-mleb-master.wmcloud.org/index.php"
+    settings.WIKI_META_BASE_API_URL = "https://lpl-mleb-master.wmcloud.org/api.php"
     settings.WIKI_META_CONTENT_MODEL = "translate-messagebundle"
     settings.WIKI_META_MCGROUP_PREFIX = "messagebundle"
     settings.WIKI_META_COURSE_PREFIX = ""


### PR DESCRIPTION
The old instance was removed. So, this PR replaces the old Wikimeta server URL with the new one.

Fixes: https://github.com/wikimedia/edx-platform/issues/511