### PR TITLE
fix: explicitly set our custom User-Agent for MetaClient API handling

### DIFF
--- a/openedx/features/wikimedia_features/meta_translations/meta_client.py
+++ b/openedx/features/wikimedia_features/meta_translations/meta_client.py
@@ -185,8 +185,12 @@ class WikiMetaClient(object):
         """
         Handles all Meta API calls.
         """
-        logger.info("Sending Meta request with data: {}, params: {}.".format(data, params))
-        response = await request_call(url=self._BASE_API_END_POINT, params=params, data=data)
+        client = getattr(settings, "PLATFORM_NAME", "wikilearn")
+        site = getattr(settings, "LMS_ROOT_URL", "https://learn.wiki/")
+        contact_mail = getattr(settings, "CONTACT_EMAIL", "comdevteam@wikimedia.org")
+        headers = {"User-Agent": f'{client}/0.13 ({site}; {contact_mail})'}
+        response = await request_call(url=self._BASE_API_END_POINT, params=params, data=data, headers=headers)
+        logger.info("Sending Meta request with data: {}, params: {}, headers: {}.".format(data, params, headers))
         return await self.parse_response(params, data, response)
 
 

--- a/openedx/features/wikimedia_features/meta_translations/meta_client.py
+++ b/openedx/features/wikimedia_features/meta_translations/meta_client.py
@@ -60,6 +60,13 @@ class WikiMetaClient(object):
             )
         )
 
+    @property
+    def wikimedia_user_agent(self):
+        client = getattr(settings, "PLATFORM_NAME", "wikilearn")
+        site = getattr(settings, "LMS_ROOT_URL", "https://learn.wiki/")
+        contact_mail = getattr(settings, "CONTACT_EMAIL", "comdevteam@wikimedia.org")
+        return f'{client}/0.13 ({site}; {contact_mail})'
+
     def get_page_redirect_url_for_title(self, title):
         """
         Returns page redirect url for given title.
@@ -185,10 +192,7 @@ class WikiMetaClient(object):
         """
         Handles all Meta API calls.
         """
-        client = getattr(settings, "PLATFORM_NAME", "wikilearn")
-        site = getattr(settings, "LMS_ROOT_URL", "https://learn.wiki/")
-        contact_mail = getattr(settings, "CONTACT_EMAIL", "comdevteam@wikimedia.org")
-        headers = {"User-Agent": f'{client}/0.13 ({site}; {contact_mail})'}
+        headers = {'User-Agent': self.wikimedia_user_agent}
         response = await request_call(url=self._BASE_API_END_POINT, params=params, data=data, headers=headers)
         logger.info("Sending Meta request with data: {}, params: {}, headers: {}.".format(data, params, headers))
         return await self.parse_response(params, data, response)


### PR DESCRIPTION
Fixes #513.

We do this after Wikimedia enforced the User-Agent policies on their APIs and our wikilearn platform was getting restricted/blocked because we did not explicitly set proper User-Agents but were relying on library default headers instead.

We now set the header to signify that the request is coming from their own wikilearn platform