### PR TITLE
fix: pin edx-sysadmin to <=0.3.0 to fulfill py3.8 condition

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -99,3 +99,7 @@ pylint<2.10.0
 # Feel free to loosen this constraint if/when it is confirmed that a later
 # version of py2neo will work with Neo4j 3.5.
 py2neo<2022
+
+# As of edx-sysadmin 0.3.1, the minimum python version required is 3.11 
+# which breaks our compatible setup with python 3.8
+edx-sysadmin<=0.3.0

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -171,6 +171,6 @@ xss-utils                           # https://github.com/edx/edx-platform/pull/2
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
 asyncio                             # Used in the meta-transaltions
 aiohttp==3.8.0                      # Used in the meta-transaltions
-edx-sysadmin                        # External requirements
+edx-sysadmin<=0.3.0                 # External requirements
 pomerge                             # Used in the localization feature
 edx-username-changer                # Used for changing usernames from admin panel.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1074,7 +1074,7 @@ yarl==1.7.0
 
 # Custom Requirements
 asyncio                             # Used in the meta-transaltions
-edx-sysadmin                        # External requirements
+edx-sysadmin<=0.3.0                 # External requirements
 pomerge                             # Used in the localization feature
 edx-username-changer                # Used for changing usernames from admin panel.
 git+https://github.com/wikimedia/edx-ora2.git@wm-v1.0#egg=ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1562,7 +1562,7 @@ zipp==3.6.0
 # Custom Requirements
 
 asyncio                             # Used in the meta-transaltions
-edx-sysadmin                        # External requirements
+edx-sysadmin<=0.3.0                 # External requirements
 pomerge                             # Used in the localization feature
 edx-username-changer                # Used for changing usernames from admin panel.
 git+https://github.com/wikimedia/edx-ora2.git@wm-v1.0#egg=ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1436,7 +1436,7 @@ zipp==3.6.0
 # Custom Requirements
 
 asyncio                             # Used in the meta-transaltions
-edx-sysadmin                        # External requirements
+edx-sysadmin<=0.3.0                 # External requirements
 pomerge                             # Used in the localization feature
 git+https://github.com/wikimedia/edx-ora2.git@wm-v1.0#egg=ora2
 


### PR DESCRIPTION
As of edx-sysadmin 0.3.1 ([Reference Commit](https://github.com/mitodl/open-edx-plugins/commit/470c6fbbd5188f2ddcc6c2c2a47484427c670c8b#diff-79faa521d2d149b27892b03ab4217d0cc90336680b274bf27757553593556735R1-R10)), the minimum required version has been updated to python 3.11. Our current setup assumes python 3.8 to be the default python environment.

Therefore, we pin the version to <=0.3.0 to fulfill the python 3.8 condition.

FYI, this is the reason that the generate translations workflow is also failing [here](https://github.com/wikimedia/edx-platform/actions/runs/17370273216/job/49304410181#step:6:743). We will need to propagate this change into the wm/localization branch as well to get this workflow to work.