### PR TITLE
feat: add topic filter dropdown in course schedule and detail page

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/settings.py
@@ -21,6 +21,7 @@ class CourseSettingsSerializer(serializers.Serializer):
     is_entrance_exams_enabled = serializers.BooleanField()
     is_prerequisite_courses_enabled = serializers.BooleanField()
     language_options = serializers.ListField(child=serializers.ListField(child=serializers.CharField()))
+    topic_options = serializers.ListField(child=serializers.CharField())
     lms_link_for_about_page = serializers.URLField()
     licensing_enabled = serializers.BooleanField()
     marketing_enabled = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
@@ -103,7 +103,12 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
 
         course_details = CourseDetails.fetch(course_key)
         serializer = CourseDetailsSerializer(course_details)
-        return Response(serializer.data)
+        
+        course_block = modulestore().get_course(course_key)
+        # Create a mutable copy and add the field
+        data = dict(serializer.data)
+        data['topic'] = course_block.other_course_settings.get('topic')
+        return Response(data)
 
     @apidocs.schema(
         body=CourseDetailsSerializer,

--- a/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
@@ -98,6 +98,8 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
             }
         ```
         """
+        # Lazy import to avoid circular import
+        from openedx_wikilearn_features.wikimedia_general.utils import get_topics #pylint: disable=import-outside-toplevel
         course_key = CourseKey.from_string(course_id)
         if not has_studio_read_access(request.user, course_key):
             self.permission_denied(request)
@@ -111,6 +113,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 'course_display_name_with_default': course_block.display_name_with_default,
                 'platform_name': settings.PLATFORM_NAME,
                 'licensing_enabled': settings.FEATURES.get("LICENSING", False),
+                'topic_options': get_topics(),
             })
 
             serializer = CourseSettingsSerializer(settings_context)

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -315,6 +315,9 @@ class CourseDetails:
 
         cls.update_about_video(block, jsondict['intro_video'], user.id)
 
+        # Lazy import to avoid circular import
+        from openedx_wikilearn_features.wikimedia_general.utils import update_other_course_settings #pylint: disable=import-outside-toplevel
+        update_other_course_settings({'topic': jsondict['topic']}, block, user)
         # Could just return jsondict w/o doing any db reads, but I put
         # the reads in as a means to confirm it persisted correctly
         return CourseDetails.fetch(course_key)


### PR DESCRIPTION
## Add Topic Filter Dropdown to Course Schedule and Details Page

### Summary
This PR adds a new "Topic" dropdown field to the course schedule and details page, allowing course authors to categorize courses by topic.

### Changes
- **API Response Enhancement**: Added `topic` field to course details GET response, fetched from `course_block.other_course_settings`
- **Settings Endpoint**: Added `topic_options` to course settings serializer and endpoint to populate dropdown choices
- **Update Handler**: Integrated topic saving in `CourseDetails.update_from_json()` by calling `update_other_course_settings()` utility function

### Technical Details
- Topic is stored in `course_block.other_course_settings` 
- Topic options are retrieved via `get_topics()` utility from the `wikimedia_general` app
- All imports from custom app are lazy-loaded to prevent initialization issues

---
**Related PRs**: 
openedx-wikilearn-features: https://github.com/wikimedia/openedx-wikilearn-features/pull/17
frontend-app-authoring: https://github.com/edly-io/frontend-app-authoring/pull/5

**Ticket**: https://github.com/wikimedia/edx-platform/issues/569