### PR TITLE
fix: correct redirect for instructor generated report links

### DIFF
--- a/openedx/features/wikimedia_features/admin_dashboard/signals.py
+++ b/openedx/features/wikimedia_features/admin_dashboard/signals.py
@@ -4,14 +4,14 @@ from django.dispatch import receiver
 from lms.djangoapps.instructor_task.models import InstructorTask
 from openedx.features.wikimedia_features.admin_dashboard.models import AdminReportTask
 from openedx.features.wikimedia_features.admin_dashboard.tasks import send_report_ready_email_task
-from openedx.features.wikimedia_features.admin_dashboard.utils import get_report_tab_link
+from openedx.features.wikimedia_features.admin_dashboard.utils import get_report_tab_link, get_instructor_tab_link
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 from celery.states import SUCCESS
 
 from opaque_keys import InvalidKeyError
 
-def send_report_ready_email(instance):
+def send_report_ready_email(instance, report_link ):
     """Send email to the user who requesed the report
 
     Args:
@@ -44,7 +44,7 @@ def send_report_ready_email(instance):
 
     email_msg = 'The "{}" report you requested for {} is ready.'.format(report_type, course_msg)
     data = {
-        "report_link": get_report_tab_link(),
+        "report_link": report_link,
         "email_msg": email_msg
     }
     send_report_ready_email_task.delay("report_ready", data, "", [email])
@@ -55,7 +55,7 @@ def send_report_ready_email(instance):
 def send_email_when_report_ready(sender, instance, created, **kwargs):
 
     if instance.task_state ==  SUCCESS:
-        send_report_ready_email(instance)
+        send_report_ready_email(instance, get_report_tab_link() )
 
 
 @receiver(post_save, sender=InstructorTask)
@@ -69,4 +69,4 @@ def send_email_when_report_ready_instructor(sender, instance, created, **kwargs)
         ]
 
     if instance.task_state ==  SUCCESS and instance.task_type in admin_report_task_types:
-        send_report_ready_email(instance)
+        send_report_ready_email(instance, get_instructor_tab_link(instance.course_id))

--- a/openedx/features/wikimedia_features/admin_dashboard/utils.py
+++ b/openedx/features/wikimedia_features/admin_dashboard/utils.py
@@ -60,3 +60,19 @@ def list_report_downloads_links(course_id="all_courses", report_name=None):
 def get_report_tab_link():
     lms_root_url = settings.LMS_ROOT_URL
     return urljoin(lms_root_url, reverse('admin_dashboard:course_reports'))
+
+def get_instructor_tab_link(course_id):
+    """
+    Build Instructor → Data Download tab link for a course.
+
+    course_id: CourseLocator
+    """
+    locator = course_id
+
+    course_key_url = (
+        f"course-v1:{locator.org}+{locator.course}+{locator.run}"
+    )
+
+    path = f"/courses/{course_key_url}/instructor#view-data_download"
+
+    return urljoin(settings.LMS_ROOT_URL, path)


### PR DESCRIPTION
This PR fixes an edge case where report generation emails always redirected users to the Admin dashboard.

Reports can be generated from both the Admin and Instructor dashboards, but the email link previously always pointed to the Admin dashboard, causing permission errors for instructors. This change ensures the email redirect matches the source of the report generation, sending admins to the Admin dashboard and instructors to the Instructor dashboard.

