### PR TITLE
Fix: Instructor Issued Certificates, report links and columns in csv

### DIFF
--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -7,9 +7,6 @@ from django.urls import path, re_path
 
 from lms.djangoapps.instructor.views import api, gradebook_api
 from openedx.core.constants import COURSE_ID_PATTERN
-from openedx_wikilearn_features.wikimedia_general.djangoapps_patches.instructor.views.certificates import (
-    get_issued_certificates as wikilearn_get_issued_certificates,
-)
 
 # These endpoints are exposing existing views in a way that can be used by MFEs
 # or other API clients. They are currently versioned at `v1` since they have
@@ -30,7 +27,7 @@ urlpatterns = [
     path('modify_access', api.ModifyAccess.as_view(), name='modify_access'),
     path('bulk_beta_modify_access', api.BulkBetaModifyAccess.as_view(), name='bulk_beta_modify_access'),
     path('get_problem_responses', api.get_problem_responses, name='get_problem_responses'),
-    path('get_issued_certificates/', wikilearn_get_issued_certificates, name='get_issued_certificates'),
+    path('get_issued_certificates/', api.GetIssuedCertificates.as_view(), name='get_issued_certificates'),
     re_path(r'^get_students_features(?P<csv>/csv)?$', api.GetStudentsFeatures.as_view(), name='get_students_features'),
     path('get_grading_config', api.GetGradingConfig.as_view(), name='get_grading_config'),
     path('get_students_who_may_enroll', api.GetStudentsWhoMayEnroll.as_view(), name='get_students_who_may_enroll'),

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -7,6 +7,9 @@ from django.urls import path, re_path
 
 from lms.djangoapps.instructor.views import api, gradebook_api
 from openedx.core.constants import COURSE_ID_PATTERN
+from openedx_wikilearn_features.wikimedia_general.djangoapps_patches.instructor.views.certificates import (
+    get_issued_certificates as wikilearn_get_issued_certificates,
+)
 
 # These endpoints are exposing existing views in a way that can be used by MFEs
 # or other API clients. They are currently versioned at `v1` since they have
@@ -27,7 +30,7 @@ urlpatterns = [
     path('modify_access', api.ModifyAccess.as_view(), name='modify_access'),
     path('bulk_beta_modify_access', api.BulkBetaModifyAccess.as_view(), name='bulk_beta_modify_access'),
     path('get_problem_responses', api.get_problem_responses, name='get_problem_responses'),
-    path('get_issued_certificates/', api.GetIssuedCertificates.as_view(), name='get_issued_certificates'),
+    path('get_issued_certificates/', wikilearn_get_issued_certificates, name='get_issued_certificates'),
     re_path(r'^get_students_features(?P<csv>/csv)?$', api.GetStudentsFeatures.as_view(), name='get_students_features'),
     path('get_grading_config', api.GetGradingConfig.as_view(), name='get_grading_config'),
     path('get_students_who_may_enroll', api.GetStudentsWhoMayEnroll.as_view(), name='get_students_who_may_enroll'),

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -1,6 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%namespace name='static' file='/static_content.html'/>
 <%!
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
@@ -43,11 +44,16 @@ from openedx.core.djangolib.markup import HTML, Text
     <p><input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate Submission Files Archive")}" data-endpoint="${ section_data['export_ora2_submission_files_url'] }"/></p>
 
   %endif
+  ## WikiLearn: point the issued-certificates report at our custom plugin endpoint
+  ## (openedx-wikilearn-features) — a per-learner report with a populated certificate
+  ## link. Only the data-endpoint changes; the stock get_issued_certificates route is
+  ## left intact for any other caller.
+  <% issued_certificates_url = reverse('wikimedia_general:general_api_v0:get_issued_certificates', kwargs={'course_key_string': str(course.id)}) %>
   <div class="issued_certificates">
     <p>${_("Click to list certificates that are issued for this course:")}</p>
     <p>
-      <input type="button" name="issued-certificates-list" value="${_("View Certificates Issued")}" data-csv="false" data-endpoint="${ section_data['get_issued_certificates_url'] }">
-      <input type="button" name="issued-certificates-csv" value="${_("Download CSV of Certificates Issued")}" data-csv="true" data-endpoint="${ section_data['get_issued_certificates_url'] }">
+      <input type="button" name="issued-certificates-list" value="${_("View Certificates Issued")}" data-csv="false" data-endpoint="${ issued_certificates_url }">
+      <input type="button" name="issued-certificates-csv" value="${_("Download CSV of Certificates Issued")}" data-csv="true" data-endpoint="${ issued_certificates_url }">
     </p>
     <div class="data-display-table certificate-data-display-table" id="data-issued-certificates-table"></div>
     <div class="issued-certificates-error request-response-error msg msg-error copy"></div>


### PR DESCRIPTION
Fixes: #[643](https://github.com/wikimedia/edx-platform/issues/643)   and #[642](https://github.com/wikimedia/edx-platform/issues/642)

## Description

The Instructor Dashboard **Data Download → "View / Download CSV of Certificates Issued"** report (`GetIssuedCertificates` in `lms/djangoapps/instructor/views/api.py`) returns a per-course aggregate (CourseID / Certificate Type / Total Issued / Date Report Run / Certificate link) whose "Certificate link" column is always blank because it reads the deprecated `GeneratedCertificate.download_url` PDF field.

This re-points the existing `get_issued_certificates` route to a per-learner view in the `openedx-wikilearn-features` plugin, reporting **Username / Grade / Certificate Type / Certificate Creation Date / Certificate link**, with the link built from `get_certificate_url(...)`. The stock view is left untouched — the only change here is one import plus the route line in `api_urls.py` (URL `name` preserved, so no frontend/template changes). Depends on the companion plugin PR and must be deployed with it.