### PR TITLE
fix: Backported #36820 to fix discussion threads

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -206,7 +206,11 @@ class User(models.Model):
                 params["count_flagged"] = str_to_bool(count_flagged)
             if not params.get("course_id"):
                 params["course_id"] = str(course_key)
-            response = forum_api.get_user_threads(**params)
+
+            user_id = params.pop("user_id", None)
+            if "text" in params:
+                params.pop("text")
+            response = forum_api.get_user_subscriptions(user_id, str(course_key), utils.clean_forum_params(params))
         else:
             response = utils.perform_request(
                 'get',
@@ -243,21 +247,17 @@ class User(models.Model):
         if is_forum_v2_enabled(course_key):
             group_ids = [retrieve_params['group_id']] if 'group_id' in retrieve_params else []
             is_complete = retrieve_params['complete']
+            params = utils.clean_forum_params({
+                "user_id": self.attributes["id"],
+                "group_ids": group_ids,
+                "course_id": course_id,
+                "complete": is_complete
+            })
             try:
-                response = forum_api.get_user(
-                    self.attributes["id"],
-                    group_ids=group_ids,
-                    course_id=course_id,
-                    complete=is_complete
-                )
+                response = forum_api.get_user(**params)
             except ForumV2RequestError as e:
                 self.save({"course_id": course_id})
-                response = forum_api.get_user(
-                    self.attributes["id"],
-                    group_ids=group_ids,
-                    course_id=course_id,
-                    complete=is_complete
-                )
+                response = forum_api.get_user(**params)
         else:
             try:
                 response = utils.perform_request(

--- a/openedx/core/djangoapps/django_comment_common/comment_client/utils.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/utils.py
@@ -103,6 +103,23 @@ def perform_request(method, url, data_or_params=None, raw=False,
             return data
 
 
+def clean_forum_params(params):
+    """Convert string booleans to actual booleans and remove None values and empty lists from forum parameters."""
+    result = {}
+    for k, v in params.items():
+        if v is not None and v != []:
+            if isinstance(v, str):
+                if v.lower() == 'true':
+                    result[k] = True
+                elif v.lower() == 'false':
+                    result[k] = False
+                else:
+                    result[k] = v
+            else:
+                result[k] = v
+    return result
+
+
 class CommentClientError(Exception):
     pass
 


### PR DESCRIPTION
## Description
Backports the forum v2 search/listing fix from upstream PR [openedx/edx-platform#36820](https://github.com/openedx/edx-platform/pull/36820) to our `develop-teak` fork. The discussion thread-listing endpoint was returning empty results when filtered by topic (`topic_id=course`), even though threads existed under that topic — causing topics to appear briefly then vanish in the Discussions MFE. The fix corrects how request params are built and sanitized (`clean_forum_params`) before being sent to the forum v2 backend.

Only the backend `comment_client` source files are backported (`thread.py`, `user.py`, `utils.py`); the upstream test files were omitted as they target v2 modules not present in this fork.

* **Impacted roles:** Learner, Course Author (anyone using course discussions)
* **No UI changes** — backend-only; the MFE renders correctly once the API returns proper data.