### PR TITLE
fix: guard against None/empty input in clean_dangerous_html

### DIFF
--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -68,8 +68,8 @@ def clean_dangerous_html(html):
         %>
         ${course_details.overview | n, clean_dangerous_html}
     """
-    if not html:
-        return html
+    if not html or not html.strip():
+        return HTML('')
     cleaner = Cleaner(style=True, inline_style=False, safe_attrs_only=False)
     html = cleaner.clean_html(html)
     return HTML(html)


### PR DESCRIPTION
## Problem
Course about page (/about) throws a 500 error when the course overview 
is None or whitespace-only. `clean_dangerous_html` passes the value 
directly to lxml, which returns None for empty input, causing:
AttributeError: 'NoneType' object has no attribute 'getroottree'

## Fix
Updated the null check in `clean_dangerous_html` (markup.py) to also 
catch whitespace-only strings, and return `HTML('')` instead of the 
raw None to stay consistent with the function's return type.

## Changes
- `openedx/core/djangolib/markup.py` — added `html.strip()` check and fixed return value

Note: this issue was previously fixed in https://github.com/wikimedia/edx-platform/pull/615 but the fix was not ported over to develop when upgrading.