### PR TITLE
fix: do not discard a cloned course when discussion migration fails

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -159,7 +159,16 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
         with store.default_store('split'):
             store.clone_course(source_course_key, destination_course_key, user_id, fields=fields)
 
-        update_unit_discussion_state_from_discussion_blocks(destination_course_key, user_id)
+        # Never let this step fail the rerun: the course has already been cloned
+        # successfully at this point, and discarding it (see the cleanup in the
+        # except block below) loses the whole rerun over an optional migration.
+        try:
+            update_unit_discussion_state_from_discussion_blocks(destination_course_key, user_id)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                'Rerun %s: failed to migrate unit discussion state; continuing',
+                destination_course_key,
+            )
 
         # set initial permissions for the user to access the course.
         initialize_permissions(destination_course_key, User.objects.get(id=user_id))


### PR DESCRIPTION
A rerun of `course-v1:Wikimedia-UK+TT001+2025` on prod failed and deleted its own destination course. The clone itself had succeeded, with all 161 blocks written correctly, but the step immediately after it raised `AttributeError: 'ErrorBlockWithMixins' object has no attribute 'discussions_settings'`, that reached the catch-all in `rerun_course`, and the handler both marked the rerun failed and called `delete_course` on the destination. Studio then 404s and the authoring MFE reports the course as still being prepared.

`update_unit_discussion_state_from_discussion_blocks` runs after `clone_course` has returned. By that point the course exists and is complete, so a failure there should not be able to take it down. Migrating unit discussion state is worth doing and worth knowing about when it fails, but it is not worth a course.

The underlying trigger was ours, a plugin receiver writing a content-scoped field inside the still-open bulk operation so that the clone read its own course root back as an `ErrorBlock`, and that is fixed separately in wikimedia/openedx-wikilearn-features#37. This guard is still worth carrying: it is the difference between a rerun that silently destroys a course and one that succeeds with a logged, recoverable gap, and it holds for any future receiver of the same shape.

Kept to the smallest possible change in core, log and continue, no behaviour change on the success path. On a legacy-provider course the migration does real work, so if it does start failing the log line is the thing to watch, and the migration can be rerun on its own afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)